### PR TITLE
Show current and new versions on update screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `makeStyles` to generate classNames instead of inline styles (11d7453beaa282002538599e26e3419343ae24ab)
 - Complete functioning auto-update system (#75) (2155eca2ccba45d3ff34064dc34280f1bc3b2d9d)
 - Add application version and about info to settings (22ad1ed320de295a03c80a9b5b3103ba994882db)
-
-<!--
-To be merged:
 - Show current version and version being updated to on update page (#77)
--->
 
 ## Changed
 

--- a/update-available.html
+++ b/update-available.html
@@ -82,26 +82,48 @@
           transform: rotate(360deg);
         }
       }
+
+      .version-change {
+        font-size: 18px;
+        line-height: 20px;
+        margin-top: 16px;
+      }
+
+      .version-change svg {
+        display: inline;
+        width: 20px;
+        height: 20px;
+        vertical-align: middle;
+      }
     </style>
   </head>
   <body>
     <span id="spinner"></span>
     <h1>Update available</h1>
     <h2>We're downloading it now...</h2>
+    <section id="version-info">
+      <p class="version-change">
+        <span id="current-version"></span>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+          <path
+            fill-rule="evenodd"
+            d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span id="new-version"></span>
+      </p>
+    </section>
   </body>
   <script>
-    // // Listen for messages
-    // const { ipcRenderer } = require('electron');
+    const params = new URLSearchParams(window.location.search);
 
-    // ipcRenderer.on('download-progress', function (event, data) {
-    //   if (!data) return;
+    const newVersion = params.get('newVersion');
+    const currentVersion = params.get('currentVersion');
 
-    //   var pct = document.getElementById('spinner');
-    //   pct.innerText = Math.floor(data.percent) + '%';
-    // });
+    if (!newVersion || !currentVersion) document.getElementById('version-info').style.display = 'none';
 
-    // setInterval(() => {
-    //   ipcRenderer.send('get-progress');
-    // }, 100);
+    document.getElementById('new-version').innerText = newVersion;
+    document.getElementById('current-version').innerText = currentVersion;
   </script>
 </html>

--- a/update-available.html
+++ b/update-available.html
@@ -46,7 +46,7 @@
       }
 
       h2 {
-        font-size: 24px;
+        font-size: 28px;
         font-weight: 500;
       }
 

--- a/updater.js
+++ b/updater.js
@@ -24,7 +24,7 @@ async function checkForUpdates(window) {
 
   if (json.data.update) {
     // Update is available!
-    window.loadURL(`file://${__dirname}/update-available.html`);
+    window.loadURL(`file://${__dirname}/update-available.html?newVersion=${json.data.info.latest || ''}&currentVersion=${APP_VERSION || ''}`);
 
     const updateDir = Path.join(electron.app.getPath('temp'), APP_NAME, `/updates`);
     const exePath = Path.join(updateDir, `/setup_${json.data.info.latest}.exe`);


### PR DESCRIPTION
## Description

During an update, the manager will show the current version it is running, and the version it's updating to.

## Review focus

Is there a better way to display this? Should we display exactly what the text shown means, or do you think it's clear enough that users will understand it.

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots

![example](https://user-images.githubusercontent.com/7406822/95686745-dd25c600-0bf7-11eb-914d-56977a1d824c.png)