### PR TITLE
Fix broken Google Fonts CSS URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,7 @@ To be merged:
 - Fix build on case sensitive filesystems (e996fb43657a97cd03f7633c79e02acf18662bb6)
 - Extract RefreshBox from inside the available liveries tab to its own component (4038edf8d930b604a464604324e97adb002b9592)
 - Make Smoketest only run on pushes to master (2b7fd6ad0e28afc25a00436e0fa016327cee82a0)
-
-<!--
-To be merged:
 - Fix incorrect Google Fonts CSS URL on update page (#78)
--->
 
 ## Removed
 

--- a/update-available.html
+++ b/update-available.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Update available</title>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap" rel="stylesheet" />
     <style>
       html,
       body {


### PR DESCRIPTION
## Description

<!-- Describe the changes this PR has -->

Fixes incorrect Google Fonts URL in `update-available.html`.

## Review focus

N/A

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshot(s)

![image](https://user-images.githubusercontent.com/7406822/95691582-fccce680-0c17-11eb-9cce-9d5dbaf4f9d7.png)
