### PR TITLE
Use new domain for CDN and API

### DIFF
--- a/src/data/Constants.json
+++ b/src/data/Constants.json
@@ -2,9 +2,9 @@
   "appName": "fs2020-livery-manager",
   "urls": {
     "managerRepo": "https://github.com/MSFS-Mega-Pack/MSFS2020-livery-manager",
-    "apiEndpoint": "https://msfs-liverypack-api.mrproper.dev",
+    "apiEndpoint": "https://api.liveriesmegapack.com",
     "devApiEndpoint": "http://localhost:2678",
-    "cdnEndpoint": "https://msfs-liverypack-cdn.mrproper.dev"
+    "cdnEndpoint": "https://manager-cdn.liveriesmegapack.com"
   },
   "dirs": {
     "downloadCache": "cache\\downloads"

--- a/updater.js
+++ b/updater.js
@@ -10,7 +10,7 @@ const request = require('request');
 // The current version of your app.
 const APP_VERSION = require('./package.json').version;
 const APP_NAME = require('./package.json').name;
-const UPDATE_URL = `https://msfs-liverypack-api.mrproper.dev/v1/get/update`;
+const UPDATE_URL = `https://api.liveriesmegapack.com/v1/get/update`;
 
 async function checkForUpdates(window) {
   let json;


### PR DESCRIPTION
## Description

<!-- Describe the changes this PR has -->

Updates the CDN and API URLs to use the new and official domain, liveriesmegapack.com.

## Review focus

Make sure I haven't missed anywhere!

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.
