### PR TITLE
Add VirusTotal scan to automated release CI

### DIFF
--- a/.github/workflows/virusTotal.yml
+++ b/.github/workflows/virusTotal.yml
@@ -1,8 +1,9 @@
-name: released
+name: After release
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   virustotal:
@@ -17,3 +18,4 @@ jobs:
           update_release_body: true
           files: |
             .exe$
+            .msi$

--- a/.github/workflows/virusTotal.yml
+++ b/.github/workflows/virusTotal.yml
@@ -1,0 +1,19 @@
+name: released
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v2
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          github_token: ${{ github.token }}
+          update_release_body: true
+          files: |
+            .exe$


### PR DESCRIPTION
## Description

Added a virusTotal scan on publish or manual trigger, will add the results at the end of the release information

## Review focus

Take a look if the script is right and should work as intended

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

</details>
