### PR TITLE
Install addon prevent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-_None_
+- Sentry loggin for livery Installation
 
 ### Changed
 
 - Allow access to setup stage without internet connectivity (#104)
+- Changed the "Failed to install livery" message
+- Prevent crashing when installing a corrupt livery
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Sentry loggin for livery Installation
+- Sentry loggin for livery Installation (#105)
 
 ### Changed
 
 - Allow access to setup stage without internet connectivity (#104)
-- Changed the "Failed to install livery" message
-- Prevent crashing when installing a corrupt livery
+- Changed the "Failed to install livery" message (#105)
+- Prevent crashing when installing a corrupt livery (#105)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Sentry loggin for livery Installation (#105)
+- Sentry logging for failed livery installations (#105)
 
 ### Changed
 

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -191,7 +191,10 @@ export default function AvailableLiveries(props) {
             closeSnackbar(s);
             enqueueSnackbar('Installation complete', { variant: 'success', persist: false });
             failures.length > 0 &&
-              enqueueSnackbar(`${failures.length} ${failures.length === 1 ? 'livery' : 'liveries'} failed to install, the team has been notified`, { variant: 'error' });
+              enqueueSnackbar(
+                `${failures.length} ${failures.length === 1 ? 'livery' : 'liveries'} failed to install, the team has been notified`,
+                { variant: 'error' }
+              );
           }}
           style={{ position: 'fixed', bottom: 24, right: 24 }}
           color="primary"

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -191,7 +191,7 @@ export default function AvailableLiveries(props) {
             closeSnackbar(s);
             enqueueSnackbar('Installation complete', { variant: 'success', persist: false });
             failures.length > 0 &&
-              enqueueSnackbar(`${failures.length} liveries failed to install, the team has been notified`, { variant: 'error' });
+              enqueueSnackbar(`${failures.length} ${failures.length === 1 ? 'livery' : 'liveries'} failed to install, the team has been notified`, { variant: 'error' });
           }}
           style={{ position: 'fixed', bottom: 24, right: 24 }}
           color="primary"

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -190,7 +190,8 @@ export default function AvailableLiveries(props) {
 
             closeSnackbar(s);
             enqueueSnackbar('Installation complete', { variant: 'success', persist: false });
-            failures.length > 0 && enqueueSnackbar(`${failures.length} liveries failed to install`, { variant: 'error' });
+            failures.length > 0 &&
+              enqueueSnackbar(`${failures.length} liveries failed to install, the team has been notified`, { variant: 'error' });
           }}
           style={{ position: 'fixed', bottom: 24, right: 24 }}
           color="primary"

--- a/src/data/Constants.json
+++ b/src/data/Constants.json
@@ -4,7 +4,8 @@
     "managerRepo": "https://github.com/MSFS-Mega-Pack/MSFS2020-livery-manager",
     "apiEndpoint": "https://api.liveriesmegapack.com",
     "devApiEndpoint": "http://localhost:2678",
-    "cdnEndpoint": "https://manager-cdn.liveriesmegapack.com"
+    "cdnEndpoint": "https://manager-cdn.liveriesmegapack.com",
+    "sentryDSN": "https://ac6e425a093744a0a72e061986c2f138@o252778.ingest.sentry.io/5431856"
   },
   "dirs": {
     "downloadCache": "cache\\downloads"

--- a/src/helpers/AddonInstaller/InstallAddon.js
+++ b/src/helpers/AddonInstaller/InstallAddon.js
@@ -61,18 +61,21 @@ export default async function InstallAddon(PlaneObject, index, total, updateProg
         const zip = new admzip(zipPath);
 
         console.log(`Created folder \n${extractDir}`);
-
-        zip.extractAllToAsync(`${extractDir}`, /*overwrite*/ true, () => {
-          try {
-            fs.unlinkSync(zipPath);
-            fs.writeFileSync(Path.join(extractDir, Constants.modLockFileName), JSON.stringify(PlaneObject, null, 2));
-            console.log(`Installed: ${zipName}`);
-            resolve();
-          } catch (err) {
-            fs.unlinkSync(zipPath);
-            reject(err);
-          }
-        });
+        try {
+          zip.extractAllToAsync(`${extractDir}`, /*overwrite*/ true, () => {
+            try {
+              fs.unlinkSync(zipPath);
+              fs.writeFileSync(Path.join(extractDir, Constants.modLockFileName), JSON.stringify(PlaneObject, null, 2));
+              console.log(`Installed: ${zipName}`);
+              resolve();
+            } catch (err) {
+              fs.unlinkSync(zipPath);
+              reject(err);
+            }
+          });
+        } catch (error) {
+          reject(error);
+        }
       });
   });
 }


### PR DESCRIPTION
**Closes #105 **

## Description

Added Sentry logging if the manager can't unzip a livery, also added a try/catch to make sure corrupt zips no longer crash the launcher

## Review focus

Check the installAddon.js

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

</details>
