### PR TITLE
Add Longitude to plane name table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ _None_
 
 ### Changed
 
-
 - Add Longitude to plane name table to stop it showing as "asobo_longitude" (#135)
 - Refresh installed liveries list after installation to show newly installed liveries (#136)
 - Make refresh button in installed liveries tab actually refresh the installed liveries list (#136)
-
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changed to the livery manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - Unreleased
+
+### Added
+
+_None_
+
+### Changed
+
+- Add Longitude to plane name table to stop it showing as "asobo_longitude" (#135)
+
+### Removed
+
+_None_
+
+### Meta
+
+_None_
+
 ## [0.2.2] - 2020-10-20
 
 ### Added

--- a/src/data/PlaneNameTable.json
+++ b/src/data/PlaneNameTable.json
@@ -14,5 +14,6 @@
   "asobo_pitts": "Aviat Pitts Special S2S",
   "asobo_savage_cub": "Zlin Aviation Savage Cub",
   "asobo_tbm930": "Daher TBM 930",
-  "asobo_xcub": "CubCrafters XCub"
+  "asobo_xcub": "CubCrafters XCub",
+  "asobo_longitude": "Cessna Citation Longitude"
 }


### PR DESCRIPTION
_No associated issue._

## Description

<!-- Describe the changes this PR has -->

Adds Longitude to the plane name table to stop it showing as "asobo_longitude".

## Review focus

<!-- Describe what reviewers should concentrate on (e.g. things you think could be implemented better, or made more efficient) -->

Is it actually called the Cessna Citation Longitude? I saw references to Textron Aviation online.

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

### Before

![image](https://user-images.githubusercontent.com/7406822/97106719-9342e280-16c3-11eb-8a3e-95142289ec29.png)

### After

![image](https://user-images.githubusercontent.com/7406822/97106680-70183300-16c3-11eb-8c78-8866de515047.png)

</details>
