### PR TITLE
Refresh installed liveries after install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changed to the livery manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - Unreleased
+
+### Added
+
+_None_
+
+### Changed
+
+- Refresh installed liveries list after installation to show newly installed liveries (#136)
+- Make refresh button in installed liveries tab actually refresh the installed liveries list (#136)
+
+### Removed
+
+_None_
+
+### Meta
+
+_None_
+
 ## [0.2.2] - 2020-10-20
 
 ### Added

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -224,20 +224,23 @@ AvailableLiveries.propTypes = {
       ),
     }),
   }),
-  installedLiveries: PropTypes.arrayOf(
-    PropTypes.shape({
-      airplane: PropTypes.string,
-      fileName: PropTypes.string,
-      displayName: PropTypes.string,
-      generation: PropTypes.string,
-      metaGeneration: PropTypes.string,
-      lastModified: PropTypes.string,
-      ETag: PropTypes.string,
-      size: PropTypes.string,
-      checkSum: PropTypes.string,
-      image: PropTypes.string,
-      smallImage: PropTypes.string,
-    })
-  ),
+  installedLiveries: PropTypes.oneOf([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        airplane: PropTypes.string,
+        fileName: PropTypes.string,
+        displayName: PropTypes.string,
+        generation: PropTypes.string,
+        metaGeneration: PropTypes.string,
+        lastModified: PropTypes.string,
+        ETag: PropTypes.string,
+        size: PropTypes.string,
+        checkSum: PropTypes.string,
+        image: PropTypes.string,
+        smallImage: PropTypes.string,
+      })
+    ),
+    PropTypes.string,
+  ]),
   setInstalledLiveries: PropTypes.func,
 };

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -26,7 +26,7 @@ import Config from 'electron-json-config';
 export default function AvailableLiveries(props) {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
-  const { fileListing, UpdateFileList, justRefreshed, setJustRefreshed } = props;
+  const { fileListing, UpdateFileList, justRefreshed, setJustRefreshed, installedLiveries, setInstalledLiveries } = props;
   let aircraft = [],
     sortedLiveries = {};
 
@@ -34,15 +34,6 @@ export default function AvailableLiveries(props) {
   const [isInstalling, setIsInstalling] = useState(false);
   /** @type {[object[], Function]} */
   const [selectedLiveries, setSelectedLiveries] = useState([]);
-  /** @type {[object[], Function]} */
-  const [installedLiveries, setInstalledLiveries] = useState(undefined);
-
-  if (typeof installedLiveries === 'undefined') {
-    setInstalledLiveries(null);
-    GetInstalledAddons()
-      .then(liveries => setInstalledLiveries(liveries))
-      .catch(e => setInstalledLiveries(e));
-  }
 
   if (typeof fileListing === 'undefined') {
     return (
@@ -233,4 +224,20 @@ AvailableLiveries.propTypes = {
       ),
     }),
   }),
+  installedLiveries: PropTypes.arrayOf(
+    PropTypes.shape({
+      airplane: PropTypes.string,
+      fileName: PropTypes.string,
+      displayName: PropTypes.string,
+      generation: PropTypes.string,
+      metaGeneration: PropTypes.string,
+      lastModified: PropTypes.string,
+      ETag: PropTypes.string,
+      size: PropTypes.string,
+      checkSum: PropTypes.string,
+      image: PropTypes.string,
+      smallImage: PropTypes.string,
+    })
+  ),
+  setInstalledLiveries: PropTypes.func,
 };

--- a/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
+++ b/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
@@ -14,9 +14,9 @@ import NoImage from '../../../images/no-image-available.png';
 import GetIndexOfLiveryInArray from '../../../helpers/GetIndexOfLiveryInArray';
 
 export default function InstalledLiveries(props) {
-  const [installedLiveries, setInstalledLiveries] = useState(undefined);
-  const [refreshing, setRefreshing] = useState(false);
+  const { fileListing, UpdateFileList, justRefreshed, setJustRefreshed, installedLiveries, setInstalledLiveries } = props;
 
+  const [refreshing, setRefreshing] = useState(false);
   const [expandedList, setExpandedList] = useState([]);
 
   function SetExpanded(aircraftName, expanded) {
@@ -41,7 +41,7 @@ export default function InstalledLiveries(props) {
         .then(liveries => {
           setInstalledLiveries(liveries);
           setRefreshing(false);
-          resolve();
+          resolve(true);
         })
         .catch(e => {
           setInstalledLiveries(e);
@@ -93,8 +93,6 @@ export default function InstalledLiveries(props) {
       return x;
     });
   }
-
-  const { fileListing, UpdateFileList, justRefreshed, setJustRefreshed } = props;
 
   if (typeof installedLiveries === 'undefined') {
     setInstalledLiveries(null);
@@ -200,4 +198,20 @@ InstalledLiveries.propTypes = {
       ),
     }),
   }),
+  installedLiveries: PropTypes.arrayOf(
+    PropTypes.shape({
+      airplane: PropTypes.string,
+      fileName: PropTypes.string,
+      displayName: PropTypes.string,
+      generation: PropTypes.string,
+      metaGeneration: PropTypes.string,
+      lastModified: PropTypes.string,
+      ETag: PropTypes.string,
+      size: PropTypes.string,
+      checkSum: PropTypes.string,
+      image: PropTypes.string,
+      smallImage: PropTypes.string,
+    })
+  ),
+  setInstalledLiveries: PropTypes.func,
 };

--- a/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
+++ b/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
@@ -32,19 +32,23 @@ export default function InstalledLiveries(props) {
       });
   }
 
-  function RefreshInstalledLiveries() {
-    setRefreshing(true);
-    setInstalledLiveries(null);
+  async function RefreshInstalledLiveries() {
+    return new Promise((resolve, reject) => {
+      setRefreshing(true);
+      setInstalledLiveries(null);
 
-    GetInstalledAddons()
-      .then(liveries => {
-        setInstalledLiveries(liveries);
-        setRefreshing(false);
-      })
-      .catch(e => {
-        setInstalledLiveries(e);
-        setRefreshing(false);
-      });
+      GetInstalledAddons()
+        .then(liveries => {
+          setInstalledLiveries(liveries);
+          setRefreshing(false);
+          resolve();
+        })
+        .catch(e => {
+          setInstalledLiveries(e);
+          setRefreshing(false);
+          reject(e);
+        });
+    });
   }
 
   const [livData, setLivData] = useState({
@@ -143,8 +147,9 @@ export default function InstalledLiveries(props) {
       <RefreshBox
         justRefreshed={!!justRefreshed}
         lastCheckedTime={fileListing && fileListing.checkedAt}
-        onRefresh={() => {
+        onRefresh={async () => {
           setRefreshing(true);
+          await RefreshInstalledLiveries();
           UpdateFileList(() => {
             setRefreshing(false);
             setJustRefreshed(new Date().getTime());

--- a/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
+++ b/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
@@ -198,20 +198,23 @@ InstalledLiveries.propTypes = {
       ),
     }),
   }),
-  installedLiveries: PropTypes.arrayOf(
-    PropTypes.shape({
-      airplane: PropTypes.string,
-      fileName: PropTypes.string,
-      displayName: PropTypes.string,
-      generation: PropTypes.string,
-      metaGeneration: PropTypes.string,
-      lastModified: PropTypes.string,
-      ETag: PropTypes.string,
-      size: PropTypes.string,
-      checkSum: PropTypes.string,
-      image: PropTypes.string,
-      smallImage: PropTypes.string,
-    })
-  ),
+  installedLiveries: PropTypes.oneOf([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        airplane: PropTypes.string,
+        fileName: PropTypes.string,
+        displayName: PropTypes.string,
+        generation: PropTypes.string,
+        metaGeneration: PropTypes.string,
+        lastModified: PropTypes.string,
+        ETag: PropTypes.string,
+        size: PropTypes.string,
+        checkSum: PropTypes.string,
+        image: PropTypes.string,
+        smallImage: PropTypes.string,
+      })
+    ),
+    PropTypes.string,
+  ]),
   setInstalledLiveries: PropTypes.func,
 };

--- a/src/helpers/AddonInstaller/getInstalledAddons.js
+++ b/src/helpers/AddonInstaller/getInstalledAddons.js
@@ -9,10 +9,26 @@ import AsyncForEach from '../AsyncForEach';
 import ThrowError from '../ThrowError';
 
 /**
+ * @typedef {{
+      airplane: string,
+      fileName: string,
+      displayName: string,
+      generation: string,
+      metaGeneration: string,
+      lastModified: string,
+      ETag: string,
+      size: string,
+      checkSum: string,
+      image: string,
+      smallImage: string,
+    }} InstalledLiveryJson
+ */
+
+/**
  * Get Installed Addons
  *
  * @export
- * @return {Array} PlaneObject  Array of Plane Objects that are installed with installLocation
+ * @return {Promise<InstalledLiveryJson[]>} PlaneObject  Array of Plane Objects that are installed with installLocation
  */
 export default async function GetInstalledAddons() {
   const Sentry = require('@sentry/electron');

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -5,6 +5,7 @@ import { InstalledLiveries, AvailableLiveries, Feed, Settings } from '../compone
 import FetchAndParseJsonManifest from '../helpers/Manifest/FetchAndParseManifest';
 import Constants from '../data/Constants.json';
 import ActiveApiEndpoint from '../data/ActiveApiEndpoint';
+import GetInstalledAddons from '../helpers/AddonInstaller/getInstalledAddons';
 
 export default function LiveryManager() {
   const [openPage, setOpenPage] = useState('dashboard');
@@ -16,6 +17,16 @@ export default function LiveryManager() {
   // Avail liveries state
   const [fileListing, setFileListing] = useState(undefined);
   const [justRefreshed, setJustRefreshed] = useState(false);
+
+  // Installed liveries state
+  const [installedLiveries, setInstalledLiveries] = useState(undefined);
+
+  if (typeof installedLiveries === 'undefined') {
+    setInstalledLiveries(null);
+    GetInstalledAddons()
+      .then(liveries => setInstalledLiveries(liveries))
+      .catch(e => setInstalledLiveries(e));
+  }
 
   useEffect(() => {
     let key;
@@ -81,6 +92,8 @@ export default function LiveryManager() {
           fileListing={fileListing}
           setFileListing={setFileListing}
           UpdateFileList={UpdateFileList}
+          installedLiveries={installedLiveries}
+          setInstalledLiveries={setInstalledLiveries}
         />
       </div>
       <div style={{ display: pg !== 'installed liveries' && 'none' }}>
@@ -89,6 +102,8 @@ export default function LiveryManager() {
           setJustRefreshed={setJustRefreshed}
           fileListing={fileListing}
           UpdateFileList={UpdateFileList}
+          installedLiveries={installedLiveries}
+          setInstalledLiveries={setInstalledLiveries}
         />
       </div>
       <div style={{ display: pg !== 'settings' && 'none' }}>


### PR DESCRIPTION
**Closes #126**

## Description

<!-- Describe the changes this PR has -->

We now...

- have extracted the available and installed tabs 'installed liveries' state to the parent 'home page' component
- ...meaning refreshing the installedliveries state after installation actually makes new liveries show in the installed tab
- refreshing inside the installed tab _actually refreshes the installed liveries list now!_

## Review focus

<!-- Describe what reviewers should concentrate on (e.g. things you think could be implemented better, or made more efficient) -->

I don't know...

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.
