### PR TITLE
Clarify liveries refresh box text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Longitude to plane name table to stop it showing as "asobo_longitude" (#135)
 - Refresh installed liveries list after installation to show newly installed liveries (#136)
 - Make refresh button in installed liveries tab actually refresh the installed liveries list (#136)
+- Clarify refresh box text from "Livery list last updated" to "Last refreshed" (#140)
 
 ### Removed
 

--- a/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
+++ b/src/components/HomeTabs/AvailableLiveries/AvailableLiveries.js
@@ -224,7 +224,7 @@ AvailableLiveries.propTypes = {
       ),
     }),
   }),
-  installedLiveries: PropTypes.oneOf([
+  installedLiveries: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({
         airplane: PropTypes.string,

--- a/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
+++ b/src/components/HomeTabs/InstalledLiveries/InstalledLiveries.js
@@ -307,7 +307,7 @@ InstalledLiveries.propTypes = {
       ),
     }),
   }),
-  installedLiveries: PropTypes.oneOf([
+  installedLiveries: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({
         airplane: PropTypes.string,

--- a/src/components/RefreshBox.js
+++ b/src/components/RefreshBox.js
@@ -22,7 +22,9 @@ export default function RefreshBox(props) {
     <Paper className={classes.root} variant="outlined">
       <Box px={2} py={1} display="flex" flexDirection="row">
         <Typography color="textSecondary" variant="body2" className={classes.text}>
-          Last refreshed:{' '}
+          <Tooltip title="When you last checked for installed and available liveries">
+            <span>Last refreshed:</span>
+          </Tooltip>{' '}
           {typeof lastCheckedTime === 'string' ? lastCheckedTime : dayjs(lastCheckedTime).format('D MMM YYYY, h:mm A') || 'unknown'}
         </Typography>
         <Box flex={1} />

--- a/src/components/RefreshBox.js
+++ b/src/components/RefreshBox.js
@@ -22,7 +22,7 @@ export default function RefreshBox(props) {
     <Paper className={classes.root} variant="outlined">
       <Box px={2} py={1} display="flex" flexDirection="row">
         <Typography color="textSecondary" variant="body2" className={classes.text}>
-          Livery list last updated:{' '}
+          Last refreshed:{' '}
           {typeof lastCheckedTime === 'string' ? lastCheckedTime : dayjs(lastCheckedTime).format('D MMM YYYY, h:mm A') || 'unknown'}
         </Typography>
         <Box flex={1} />


### PR DESCRIPTION
Closes #137

## Description

<!-- Describe the changes this PR has -->

I've renamed this to 'Last refreshed' from 'Livery list last updated' as some people were interpreting this to mean that new liveries were being added.

I've also added a tooltip for extra sure-ness, too.

## Review focus

<!-- Describe what reviewers should concentrate on (e.g. things you think could be implemented better, or made more efficient) -->

Is the tooltip necessary? Is there a better way to describe this time?

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

![image](https://user-images.githubusercontent.com/7406822/97117519-8f838000-1704-11eb-8bc6-a6b5d64bedbc.png)
![image](https://user-images.githubusercontent.com/7406822/97117529-a1652300-1704-11eb-8171-d91c4fab718c.png)


</details>
