### PR TITLE
Create Community folder if it doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changed marked with `[DEV]` are invisible to users, and purely for the benefit o
 - Clarify refresh box text from "Livery list last updated" to "Last refreshed" (#140)
 - Add missing aircraft translations (#142)
 - \[DEV\] Fix broken sourcemap uploads (#143)
+- \[DEV\] Create community folder if it does not exist, should fix the blank screen bug. (#148)
 
 ### Removed
 

--- a/src/helpers/MSFS/Directories/GetPackagesDirectory.js
+++ b/src/helpers/MSFS/Directories/GetPackagesDirectory.js
@@ -36,6 +36,9 @@ export default async function GetPackagesDirectory() {
       installPath = Path.resolve(line.slice('InstalledPackagesPath "'.length, -1));
       installPath += '\\Community';
       installPath = Path.normalize(installPath);
+      try {
+        fs.existsSync(installPath) || fs.mkdirSync(installPath);
+      } catch (error) {}
     }
   });
 

--- a/src/helpers/MSFS/Directories/GetPackagesDirectory.js
+++ b/src/helpers/MSFS/Directories/GetPackagesDirectory.js
@@ -1,5 +1,6 @@
 const FS = require('fs').promises;
 const Path = require('path');
+const fs = require('fs');
 
 const MSFS_DIRECTORY = Path.join(process.env.LOCALAPPDATA + '\\Packages\\Microsoft.FlightSimulator_8wekyb3d8bbwe\\');
 const MSFS_DIRECTORY_STEAM = Path.join(process.env.APPDATA + '\\Microsoft Flight Simulator\\');
@@ -38,7 +39,9 @@ export default async function GetPackagesDirectory() {
       installPath = Path.normalize(installPath);
       try {
         fs.existsSync(installPath) || fs.mkdirSync(installPath);
-      } catch (error) {}
+      } catch (error) {
+        console.log(error);
+      }
     }
   });
 


### PR DESCRIPTION
**Closes #138 **

## Description

Creates the community folder if it doesn't exist. According to: https://github.com/MSFS-Mega-Pack/MSFS2020-livery-manager/issues/146#issuecomment-716828995, the community folder is not always here, causing blank screen.

## Review focus

Check if this should fix the issue and if we can add some code to the catch when creating it :)

## Checklist

- [x] I have run `yarn format`
- [x] I have run `yarn eslint` and fixed any issues
- [x] This PR does not add any errors to the console

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

<!-- upload any screenshots or recordings demonstrating the issue here-->

</details>
