### PR TITLE
Add german language (de-DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Changed marked with `[DEV]` are invisible to users, and purely for the benefit o
 
 - Add Swedish language (thank you @brezedc!) (#180)
 - Add Dutch language (thank you @JSSRDRG!) (#188)
+- Add German language (thank you @dominique-mueller!) (#198)
 
 ### Changed
 
-- Fixed issue with custom languages that didn't affect anyone in 0.3.1, but would have from this update (#182)
+- [DEV] Fixed issue with custom languages that didn't affect anyone in 0.3.1, but would have from this update (@davwheat and @dominique-mueller) (#182 and #198)
+- [DEV] Fix incorrect prop types (@dominique-mueller) (#198)
 
 ### Removed
 

--- a/src/components/HomeTabs/Feed/Article.js
+++ b/src/components/HomeTabs/Feed/Article.js
@@ -5,6 +5,7 @@ import ArticleClass from '../../../models/Article';
 import { Typography, makeStyles, Divider, Paper, Box } from '@material-ui/core';
 import MarkdownRenderer from '../../MarkdownRenderer';
 import LocaleContext from '../../../locales/LocaleContext';
+import * as dayjs from 'dayjs';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -48,6 +49,10 @@ export default function Article(props) {
   const CurrentLocale = React.useContext(LocaleContext);
   const { article } = props;
 
+  const date = dayjs(article.date)
+    .locale(CurrentLocale ? CurrentLocale.locale : 'en')
+    .format(CurrentLocale ? CurrentLocale.translate('models.article.date_format') : 'ddd D MMM YYYY, h:mm A');
+
   const classes = useStyles();
 
   return (
@@ -58,7 +63,7 @@ export default function Article(props) {
         </Typography>
         <Typography variant="caption" component="h3" gutterBottom color="textSecondary">
           {CurrentLocale.translate('manager.components.feed_article.authored_by', { author: article.author })}{' '}
-          <span className={classes.bullet} /> {article.dateString}
+          <span className={classes.bullet} /> {date}
         </Typography>
         <Divider />
         <article className={classes.article}>

--- a/src/components/HomeTabs/Feed/Article.js
+++ b/src/components/HomeTabs/Feed/Article.js
@@ -49,9 +49,7 @@ export default function Article(props) {
   const CurrentLocale = React.useContext(LocaleContext);
   const { article } = props;
 
-  const date = dayjs(article.date)
-    .locale(CurrentLocale ? CurrentLocale.locale : 'en')
-    .format(CurrentLocale ? CurrentLocale.translate('models.article.date_format') : 'ddd D MMM YYYY, h:mm A');
+  const date = dayjs(article.date).locale(CurrentLocale.locale).format(CurrentLocale.translate('models.article.date_format'));
 
   const classes = useStyles();
 

--- a/src/components/HomeTabs/Feed/Feed.js
+++ b/src/components/HomeTabs/Feed/Feed.js
@@ -24,7 +24,7 @@ export default function Feed(props) {
   const [fullHistory, setFullHistory] = [props.fullHistory, props.setFullHistory];
 
   if (typeof feed === 'undefined') {
-    GetActiveFeed()
+    GetActiveFeed(CurrentLocale)
       .then(f => setFeed(f))
       .catch(() => setFeed(null));
 
@@ -80,7 +80,7 @@ export default function Feed(props) {
               variant="outlined"
               onClick={async () => {
                 setFullHistory(false);
-                const feed = await GetFeedHistory();
+                const feed = await GetFeedHistory(CurrentLocale);
                 setFullHistory(feed);
               }}
               disabled={fullHistory === false}

--- a/src/components/HomeTabs/InstalledLiveries/AircraftAccordion.js
+++ b/src/components/HomeTabs/InstalledLiveries/AircraftAccordion.js
@@ -220,6 +220,8 @@ AircraftAccordion.propTypes = {
   }),
   expanded: PropTypes.bool.isRequired,
   setExpanded: PropTypes.func.isRequired,
-  fileListing: PropTypes.shape({ data: { fileList: PropTypes.arrayOf(CustomPropTypes.Livery) } }),
+  fileListing: PropTypes.shape({
+    data: PropTypes.shape({ fileList: PropTypes.arrayOf(CustomPropTypes.Livery) }),
+  }),
   RefreshAllData: PropTypes.func.isRequired,
 };

--- a/src/components/HomeTabs/InstalledLiveries/FullInstalledTable.js
+++ b/src/components/HomeTabs/InstalledLiveries/FullInstalledTable.js
@@ -116,7 +116,7 @@ FullInstalledTable.propTypes = {
   SetExpanded: PropTypes.func.isRequired,
   expandedList: PropTypes.arrayOf(PropTypes.string).isRequired,
   fileListing: PropTypes.shape({
-    data: PropTypes.shape({ fileList: PropTypes.arrayOf(CustomPropTypes.Livery) })
+    data: PropTypes.shape({ fileList: PropTypes.arrayOf(CustomPropTypes.Livery) }),
   }),
   RefreshAllData: PropTypes.func.isRequired,
 };

--- a/src/components/HomeTabs/InstalledLiveries/FullInstalledTable.js
+++ b/src/components/HomeTabs/InstalledLiveries/FullInstalledTable.js
@@ -115,6 +115,8 @@ FullInstalledTable.propTypes = {
   RemoveLiveryFromData: PropTypes.func,
   SetExpanded: PropTypes.func.isRequired,
   expandedList: PropTypes.arrayOf(PropTypes.string).isRequired,
-  fileListing: PropTypes.shape({ data: { fileList: PropTypes.arrayOf(CustomPropTypes.Livery) } }),
+  fileListing: PropTypes.shape({
+    data: PropTypes.shape({ fileList: PropTypes.arrayOf(CustomPropTypes.Livery) })
+  }),
   RefreshAllData: PropTypes.func.isRequired,
 };

--- a/src/components/HomeTabs/InstalledLiveries/LiveryList.js
+++ b/src/components/HomeTabs/InstalledLiveries/LiveryList.js
@@ -80,9 +80,9 @@ LiveryList.propTypes = {
     RefreshInstalledLiveries: PropTypes.func,
   }),
   fileListing: PropTypes.shape({
-    data: {
+    data: PropTypes.shape({
       fileList: PropTypes.arrayOf(CustomPropTypes.Livery),
-    },
+    }),
   }),
   liveryDataFuncs: PropTypes.shape({
     add: PropTypes.func.isRequired,

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -24,24 +24,30 @@ const useStyles = makeStyles({
 });
 
 export default function MainPage(props) {
-  const CurrentLocale = React.useContext(LocaleContext);
+  const { children, onTabChange, scrollInnerStyle } = props;
+
+  const CurrentLocal = React.useContext(LocaleContext);
 
   const TABS = [
     {
-      label: CurrentLocale.translate('manager.tabs.tab_labels.update_feed'),
+      id: 'update_feed',
+      label: CurrentLocal.translate('manager.tabs.tab_labels.update_feed'),
       icon: <HomeIcon />,
       iconOnly: true,
     },
     {
-      label: CurrentLocale.translate('manager.tabs.tab_labels.available_liveries'),
+      id: 'available_liveries',
+      label: CurrentLocal.translate('manager.tabs.tab_labels.available_liveries'),
       iconOnly: false,
     },
     {
-      label: CurrentLocale.translate('manager.tabs.tab_labels.installed_liveries'),
+      id: 'installed_liveries',
+      label: CurrentLocal.translate('manager.tabs.tab_labels.installed_liveries'),
       iconOnly: false,
     },
     {
-      label: CurrentLocale.translate('manager.tabs.tab_labels.settings'),
+      id: 'settings',
+      label: CurrentLocal.translate('manager.tabs.tab_labels.settings'),
       iconOnly: false,
     },
   ];
@@ -50,10 +56,9 @@ export default function MainPage(props) {
 
   const handleChange = (_, newValue) => {
     setSelectedTab(newValue);
-    onTabChange(TABS[newValue].label);
+    onTabChange(TABS[newValue].id);
   };
 
-  const { children, onTabChange, scrollInnerStyle } = props;
   const classes = useStyles();
 
   return (

--- a/src/components/RefreshBox.js
+++ b/src/components/RefreshBox.js
@@ -32,7 +32,7 @@ export default function RefreshBox(props) {
           {typeof lastCheckedTime === 'string'
             ? lastCheckedTime
             : dayjs(lastCheckedTime)
-                .locale(CurrentLocale ? CurrentLocale.locale : 'en')
+                .locale(CurrentLocale.locale)
                 .format(CurrentLocale.translate('manager.components.refresh_box.date_format')) ||
               CurrentLocale.translate('manager.components.refresh_box.unknown_time')}
         </Typography>

--- a/src/components/RefreshBox.js
+++ b/src/components/RefreshBox.js
@@ -31,7 +31,9 @@ export default function RefreshBox(props) {
           </Tooltip>{' '}
           {typeof lastCheckedTime === 'string'
             ? lastCheckedTime
-            : dayjs(lastCheckedTime).format(CurrentLocale.translate('manager.components.refresh_box.date_format')) ||
+            : dayjs(lastCheckedTime)
+                .locale(CurrentLocale ? CurrentLocale.locale : 'en')
+                .format(CurrentLocale.translate('manager.components.refresh_box.date_format')) ||
               CurrentLocale.translate('manager.components.refresh_box.unknown_time')}
         </Typography>
         <Box flex={1} />

--- a/src/helpers/Feed/GetActiveFeed.js
+++ b/src/helpers/Feed/GetActiveFeed.js
@@ -40,7 +40,6 @@ export default async function GetActiveFeed(CurrentLocale) {
         title: article.title,
         author: article.author,
         content: text || CurrentLocale.translate('helpers.get_active_feed.fetch_fail_article_text'),
-        CurrentLocale,
       });
 
       feedArticles.push(a);

--- a/src/helpers/Feed/GetFeedHistory.js
+++ b/src/helpers/Feed/GetFeedHistory.js
@@ -41,7 +41,6 @@ export default async function GetFeedHistory(CurrentLocale) {
         title: article.title,
         author: article.author,
         content: text || CurrentLocale.translate('helpers.get_feed_history.fetch_fail_article_text'),
-        CurrentLocale,
       });
 
       feedArticles.push(a);

--- a/src/locales/de-DE/index.js
+++ b/src/locales/de-DE/index.js
@@ -1,1 +1,2 @@
+import 'dayjs/locale/de';
 export default from './locale.json';

--- a/src/locales/de-DE/index.js
+++ b/src/locales/de-DE/index.js
@@ -1,0 +1,1 @@
+export default from './locale.json';

--- a/src/locales/de-DE/locale.json
+++ b/src/locales/de-DE/locale.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Deutsch",
-    "localeId": "de-DE"
+    "localeId": "de"
   },
   "strings": {
     "common": {

--- a/src/locales/de-DE/locale.json
+++ b/src/locales/de-DE/locale.json
@@ -1,0 +1,316 @@
+{
+  "info": {
+    "name": "Deutsch",
+    "localeId": "de-DE"
+  },
+  "strings": {
+    "common": {
+      "coming_soon": "Feature kommt bald."
+    },
+    "models": {
+      "article": {
+        "date_format": "ddd D. MMM YYYY, H:mm"
+      }
+    },
+    "helpers": {
+      "validate_fs_directory": {
+        "choose_directory": "Bitte wähle ein Verzeichnis aus",
+        "path_doesnt_exist": "Der ausgewählte Pfad existiert nicht",
+        "invalid_path": "Bitte stelle sicher, dass der Community-Ordner ausgewählt ist"
+      },
+      "show_native_dialog": {
+        "yes_button": "&Ja",
+        "no_button": "&Nein",
+        "cancel_button": "&Abbrechen"
+      },
+      "install_addon": {
+        "progress_notifications": {
+          "downloading_livery": "Livery {{current}} von {{total}} wird heruntergeladen",
+          "extracting_livery": "Livery {{current}} von {{total}} wird entpackt"
+        }
+      },
+      "delete_addon": {
+        "delete_path_fail": "Beim Löschen des Addon-Pfads ist ein Fehler aufgetreten",
+        "delete_path_success": "Das Addon wurde erfolgreich gelöscht",
+        "non_existant": "Der Addon-Pfad existiert nicht"
+      },
+      "get_active_feed": {
+        "fetch_fail": "Beim Laden des aktuellen Feeds über die API ist ein Fehler aufgetreten.",
+        "fetch_fail_article_text": "Fehler beim Laden des Artikels. Sollte der Fehler weiterhin auftreten, [diesen bitte an die Entwickler melden](https://github.com/MSFS-Mega-Pack/MSFS2020-livery-manager/issues/new).\n\nInfo: `fetch` failed in `GetActiveFeed.js`"
+      },
+      "get_feed_history": {
+        "fetch_fail": "Beim Laden des aktuellen Feeds über die API ist ein Fehler aufgetreten.",
+        "fetch_fail_article_text": "Fehler beim Laden des Artikels. Sollte der Fehler weiterhin auftreten, [diesen bitte an die Entwickler melden](https://github.com/MSFS-Mega-Pack/MSFS2020-livery-manager/issues/new).\n\nInfo: `fetch` failed in `GetActiveFeed.js`"
+      }
+    },
+    "manager": {
+      "splash_screen": {
+        "loading": "Wird geladen..."
+      },
+      "setup": {
+        "back_button": "Zurück",
+        "next_button": "Weiter",
+        "finish_button": "Abschließen",
+        "welcome_page": {
+          "heading": "Willkommen zum {{app_name}}",
+          "description": "Bevor der Liveries Manager verwendet werden kann, musst du zuerst ein paar wenige Dinge einrichten - so stelen wir sicher, dass alles nach Plan verläuft."
+        },
+        "locale_page": {
+          "heading": "Wähle deine Sprache aus",
+          "description": "Alle Sprachen werden von der Community bereitgestellt. Bitte melde Probleme mit der Übersetzung auf GitHub.",
+          "help_translate_link": "Warum nicht dabei unterstützen, den Liveries Manager in deine Sprache zu übersetzen?",
+          "dropdown": {
+            "label": "Sprache"
+          }
+        },
+        "community_directory": {
+          "heading": "Finde deinen Community-Ordner",
+          "description": "Bitte stelle sicher, dass der Pfad auf deinen Community-Ordner verweist. Sollte das nicht der Fall sein, wähle bitte den korrekten Pfad aus.",
+          "text_field": {
+            "label": "Pfad zum Community-Ordner",
+            "browse_button_sr_text": "Durchsuchen..."
+          }
+        },
+        "complete_page": {
+          "heading": "Einrichtung abgeschlossen",
+          "description1": "Du bist bereit, abzuheben!",
+          "description2": "Klicke auf \"Abschließen\", um deine Einstellungen zu bestätigen und den Liveries Manager zu starten."
+        }
+      },
+      "tabs": {
+        "tab_labels": {
+          "update_feed": "Dashboard",
+          "available_liveries": "Verfügbare Liveries",
+          "installed_liveries": "Installierte Liveries",
+          "settings": "Einstellungen"
+        }
+      },
+      "components": {
+        "feed_article": {
+          "authored_by": "Geschrieben von {{author}}"
+        },
+        "badges": {
+          "update_available": {
+            "tooltip": "Wechsle zum Bereich \"Installierte Liveries\", um dieses Livery zu aktualisieren",
+            "content": "Update verfügbar"
+          },
+          "installed": {
+            "tooltip": "Wechsle zum Bereich \"Installierte Liveries\", um dieses Livery zu aktualisieren, deinstallieren, neu zu installieren",
+            "content": "Installiert"
+          }
+        },
+        "refresh_box": {
+          "date_format": "D. MMM, H:mm",
+          "last_refreshed": "Zuletzt aktualisiert:",
+          "last_refreshed_explanation_tooltip": "Zeitpunkt, an welchem zuletzt nach installierten und verfügbaren Liveries geprüft wurde",
+          "refresh_button": {
+            "tooltip": {
+              "default": "Verfügbare Liveries aktualisieren",
+              "rate_limited": "Übertragungsbegrenzung aktiv: Du musst mind. {{interval}} Sekunden zwischen Aktualisierungen warten"
+            },
+            "unknown_time": "unbekannt"
+          }
+        },
+        "error_dialog": {
+          "error": "Fehler",
+          "suggestions": "Vorschlag",
+          "close_dialog_button": "Schließen"
+        },
+        "offline_error": {
+          "title": "Du bist offline",
+          "paragraph1": "Der Liveries Manager benötigt eine Internetverbindung, um alle Funktionen bereit zu stellen.",
+          "paragraph2": "Diese Nachricht verschwindet automatisch, sobald eine Internetverbindung erkannt wird."
+        }
+      },
+      "pages": {
+        "feed": {
+          "error_more_info_button": "Mehr Informationen",
+          "no_more_posts": {
+            "heading": "Das war es schon!",
+            "info": "Du bist am Ende des News-Feeds angekommen"
+          },
+          "view_more_updates_button": "Alle News anzeigen",
+          "errors": {
+            "generic_message": "Beim Laden des News-Feeds ist ein Fehler aufgetreten.",
+            "unknown_error": "Ein unbekannter Fehler ist aufgetreten",
+            "feed_unknown": "Die News-Daten, die von der API geladen wurden, sind ungültig. (null_err)"
+          }
+        },
+        "available_liveries": {
+          "errors": {
+            "installed_addons_fail": {
+              "title": "keine installierten Liveries gefunden",
+              "error_text": "Wir konnten die Liste der installierten Liveries nicht laden. Hast du vielleicht den Community-Ordner verschoben oder gelöscht?",
+              "suggestion1": "Der eingerichtete Pfad ist {{path}}. Ist der Pfad weiterhin korrekt?",
+              "suggestion2": "Du kannst den Pfad zu deinem Community-Ordner im Bereich \"Einstellungen\" ändern."
+            }
+          },
+          "progress_notifications": {
+            "begin_install": "Liveries werden installiert...",
+            "install_complete": "{{total}} [[total||Livery|Liveries]] erfolgreich installiert",
+            "install_failed": "{{fails}} [[fails||Livery|Liveries]] konnte(n) nicht installiert werden. Das Team wurde benachrichtigt."
+          },
+          "fab_currently_installing": "{{total}} [[total||Livery|Liveries]] ({{size}} MB) werden installiert",
+          "fab_install": "{{total}} [[total||Livery|Liveries]] ({{size}} MB) installieren",
+          "components": {
+            "refresh_box": {
+              "refreshing_now": "Wird aktualisiert..."
+            },
+            "aircraft_accordion": {
+              "available_count": "{{total}} [[total||livery|liveries]] available",
+              "installed_count": "{{total}} installed",
+              "info_fields": {
+                "aircraft_name": {
+                  "title": "Flugzeug"
+                },
+                "total_livery_count": {
+                  "title": "Verfübare Liveries",
+                  "value": "{{total}} verfügbar"
+                },
+                "total_installed_count": {
+                  "title": "Installierte Liveries",
+                  "value": "{{count}} von {{total}} installiert"
+                }
+              },
+              "buttons": {
+                "select_all_btn": "Alle auswählen",
+                "deselect_all_btn": "Alle abwählen"
+              },
+              "liveries_heading": "Liveries"
+            },
+            "livery_row": {
+              "expand_livery_details_tooltip": "Informationen zum Livery anzeigen",
+              "shrink_livery_details_tooltip": "Informationen zum Livery ausblenden",
+              "info_fields": {
+                "version": {
+                  "title": "Version",
+                  "tooltip": "Dieser Text repräsentiert die aktuelle verfügbare Version des Livery. Sollte sich deine Version unterscheiden, ist ein Update für dieses Livery verfügbar."
+                },
+                "thumbnail": {
+                  "title": "Vorschau"
+                }
+              }
+            }
+          }
+        },
+        "installed_liveries": {
+          "warning_cannot_remove_multiple_liveries": "Zum aktuellen Zeitpunkt kannst du nicht mehrere Liveries gleichzeitig aktualisieren oder deinstallieren. Aber keine Sorge, dieses Feature kommt bald in einem zukünftigen Update.",
+          "progress_notifications": {
+            "begin_update": "Liveries werden aktualisiert...",
+            "update_complete": "{{total}} [[total||Livery|Liveries]] erfolgreich aktualisiert",
+            "update_failed": "{{fails}} [[fails||Livery|Liveries]] konnte(n) nicht aktualisiert werden. Das Team wurde benachrichtigt."
+          },
+          "components": {
+            "refresh_box": {
+              "refreshing_now": "Wird aktualisiert..."
+            },
+            "aircraft_accordion": {
+              "liveries_heading": "Liveries",
+              "installed_count": "{{total}} installiert",
+              "update_count": "{{updates}} [[updates||Livery kann aktualisiert werden|Liveries können aktualisiert werden]]"
+            },
+            "list_row": {
+              "update": {
+                "button": "Aktualisieren"
+              },
+              "help": {
+                "tooltip": {
+                  "update": "Livery aktualisieren",
+                  "delete": "Livery deinstallieren",
+                  "delete_timer": "Für {{time}} Sekunden gedrückt halten, um das Livery zu deinstallieren"
+                },
+                "snackbar": {
+                  "hold_to_remove": "Um ein Livery zu deinstallieren, klicke auf den Button und halte gedrückt für {{time}} Sekunden"
+                }
+              }
+            }
+          },
+          "notification": {
+            "no_liveries_to_remove": "Du hast noch keine Liveries installiert!",
+            "removing_livery": "Livery {{current}} von {{total}} wird deinstalliert",
+            "remove_all_success": "{{total}} [[total||Livery|Liveries]] erfolgreich deinstalliert",
+            "remove_all_failures": "{{errors}} [[errors||Livery|Liveries]] konnten nicht deinstalliert werden",
+            "deletion": {
+              "fail1": "Livery konnte nicht deinstalliert werden: no obj passed",
+              "fail2": "Livery konnte nicht deinstalliert werden: unknown location",
+              "fail3": "Livery konnte nicht deinstalliert werden: folder not found",
+              "fail4": "Livery konnte nicht deinstalliert werden: {{error}}",
+              "fail5": "Livery konnte nicht deinstalliert werden: unknown error",
+              "success": "Livery erfolgreich deinstalliert"
+            },
+            "no_liveries_to_update": "Du hast noch keine Liveries installiert!",
+            "update_all_success": "{{total}} [[total||Livery|Liveries]] erfolgreich aktualisiert",
+            "update_all_failures": "{{errors}} [[errors||Livery|Liveries]] konnten nicht aktualisiert werden",
+            "updating_livery": "Livery {{current}} von {{total}} wird aktualisiert"
+          },
+          "dialog": {
+            "uninstall_all": {
+              "title": "Alle Liveries deinstallieren?",
+              "message": "Bist du dir sicher, dass du ALLE LIVERIES deinstallieren möchtest?",
+              "detail": "Die Deinstallation kann weder pausiert noch abgebrochen werden. Um deine Liveries zurück zu bekommen, musst du sie erneut installieren."
+            },
+            "update_all": {
+              "title": "Alle Liveries aktualisieren?",
+              "message": "Bist du dir sicher, dass du ALLE LIVERIES aktualisieren möchtest?",
+              "detail": "Die Aktualisierung kann weder pausiert noch abgebrochen werden."
+            }
+          },
+          "button": {
+            "remove_all_liveries": "Alle deinstallieren",
+            "update_all": "Alle aktualisieren"
+          },
+          "no_liveries_installed": {
+            "more_info_button": "Mehr Informationen",
+            "message": "Es wurden keine installieren Liveries gefunden",
+            "info": "We konnen keine Mega-Pack Liveries im ausgewählten Community-Ordner finden.\n\nWenn du Liveries über das Mega-Pack (zip-Datei) installiert hast, tauchen sie hier nicht auf; stattdessen müssen sie über den Liveries Manager installiert werden."
+          }
+        },
+        "settings": {
+          "advanced_settings": {
+            "enabled_notification": "Erweiterte Einstellungen aktiviert",
+            "disabled_notification": "Erweiterte Einstellungen deaktiviert",
+            "dialog_title": "Erweiterte Einstellungen aktivieren?",
+            "dialog_body": "Erweiterte Einstellungen aktivieren?",
+            "dialog_detail": "Fahre nur fort, wenn du von einem Entwickler dazu aufgefordert wurdest. Dies kann unbeabsichtigte Folgen haben. Du wurdest gewarnt!"
+          },
+          "footer": {
+            "line1": "{{appName}} — Entwickelt für das Liveries Mega-Pack",
+            "line2": "© {{year}} — Alle Rechte vorbehalten — ",
+            "version": "v{{version}}",
+            "source_repo_and_license": "Quellcode und Lizenz ansehen"
+          },
+          "errors_in_inputs": "Bitte behebe vor dem Speichern alle Fehler",
+          "save_settings_changes": "Klicke auf \"Speichern\", um alle Änderungen zu übernehmen",
+          "all_changes_saved": "Alle Änderungen gespeichert",
+          "save_button": "Speichern",
+          "user_settings": {
+            "community_folder": {
+              "name": "Community-Ordner",
+              "input_label": "Pfad zum Community-Ordner",
+              "browse_button_sr_text": "Durchsuchen...",
+              "reset_button": "Änderung rückgängig machen",
+              "open_in_explorer": "Öffne Ordner im Explorer",
+              "open_in_explorer_opening": "Ordner wird geöffnet..."
+            },
+            "locale_selection": {
+              "name": "Liveries Manager Sprache",
+              "label": "Sprache"
+            },
+            "cache_clear": {
+              "name": "Caching",
+              "clearing_cache_notification": "Cache wird geleert. Dieser Prozess kann einige Minuten dauern.",
+              "cache_clear_success_notification": "Cache erfolgreich geleert!",
+              "cache_clear_error_notification": "Beim Leeren des Caches ist ein Fehler aufgetreten",
+              "purge_cache_button": "Cache löschen"
+            },
+            "reset_manager_to_defaults": {
+              "name": "Liveries Manager zurücksetzen",
+              "detail": "Dieser Prozess setzt alle Einstellungen zurück und startet die Anwendung neu. Bereits installierte Liveries bleiben erhalten und werden automatisch erkannt.",
+              "reset_btn": "Alle Einstellungen zurücksetzen"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/locales/de-DE/locale.json
+++ b/src/locales/de-DE/locale.json
@@ -95,7 +95,7 @@
             "content": "Update verfügbar"
           },
           "installed": {
-            "tooltip": "Wechsle zum Bereich \"Installierte Liveries\", um dieses Livery zu aktualisieren, deinstallieren, neu zu installieren",
+            "tooltip": "Wechsle zum Bereich \"Installierte Liveries\", um dieses Livery zu aktualisieren, deinstallieren, oder neu zu installieren",
             "content": "Installiert"
           }
         },
@@ -157,8 +157,8 @@
               "refreshing_now": "Wird aktualisiert..."
             },
             "aircraft_accordion": {
-              "available_count": "{{total}} [[total||livery|liveries]] available",
-              "installed_count": "{{total}} installed",
+              "available_count": "{{total}} verfügbar",
+              "installed_count": "{{total}} installiert",
               "info_fields": {
                 "aircraft_name": {
                   "title": "Flugzeug"
@@ -207,7 +207,7 @@
             "aircraft_accordion": {
               "liveries_heading": "Liveries",
               "installed_count": "{{total}} installiert",
-              "update_count": "{{updates}} [[updates||Livery kann aktualisiert werden|Liveries können aktualisiert werden]]"
+              "update_count": "{{updates}} [[updates||kann aktualisiert werden|können aktualisiert werden]]"
             },
             "list_row": {
               "update": {
@@ -289,11 +289,11 @@
               "input_label": "Pfad zum Community-Ordner",
               "browse_button_sr_text": "Durchsuchen...",
               "reset_button": "Änderung rückgängig machen",
-              "open_in_explorer": "Öffne Ordner im Explorer",
-              "open_in_explorer_opening": "Ordner wird geöffnet..."
+              "open_in_explorer": "Im Explorer öffnen",
+              "open_in_explorer_opening": "Wird geöffnet..."
             },
             "locale_selection": {
-              "name": "Liveries Manager Sprache",
+              "name": "Sprache",
               "label": "Sprache"
             },
             "cache_clear": {

--- a/src/locales/en-GB/index.js
+++ b/src/locales/en-GB/index.js
@@ -1,1 +1,2 @@
+import 'dayjs/locale/en-gb';
 export default from './locale.json';

--- a/src/locales/en-GB/locale.json
+++ b/src/locales/en-GB/locale.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "English (United Kingdom)",
-    "localeId": "en-GB"
+    "localeId": "en-gb"
   },
   "strings": {
     "common": {

--- a/src/locales/en-US/index.js
+++ b/src/locales/en-US/index.js
@@ -1,1 +1,2 @@
+import 'dayjs/locale/en';
 export default from './locale.json';

--- a/src/locales/en-US/locale.json
+++ b/src/locales/en-US/locale.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "English (United States)",
-    "localeId": "en-US"
+    "localeId": "en"
   },
   "strings": {
     "common": {

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,3 +1,4 @@
+export { default as deDE } from './de-DE';
 export { default as enGB } from './en-GB';
 export { default as enUS } from './en-US';
 export { default as seSE } from './se-SE';

--- a/src/models/Article.js
+++ b/src/models/Article.js
@@ -1,5 +1,4 @@
 import ThrowError from '../helpers/ThrowError';
-import dayjs from 'dayjs';
 
 /**
  * Article for use on the update feed on the home page.
@@ -52,19 +51,6 @@ export default class Article {
    */
   get date() {
     return this.#date;
-  }
-
-  /**
-   * Date, formatted nicely as a string
-   *
-   * @type {String}
-   * @readonly
-   * @memberof Article
-   */
-  get dateString() {
-    return dayjs(this.#date).format(
-      this.#CurrentLocale ? this.#CurrentLocale.translate('models.article.date_format') : 'ddd D MMM YYYY, h:mm A'
-    );
   }
 
   /**

--- a/src/models/Article.js
+++ b/src/models/Article.js
@@ -13,11 +13,6 @@ export default class Article {
   #content;
 
   /**
-   * @type {import("../locales/Locale").default?}
-   */
-  #CurrentLocale;
-
-  /**
    * Creates a new instance of an Article.
    *
    * Either content or contentUrl MUST be provided.
@@ -27,10 +22,9 @@ export default class Article {
    * @param {String} options.title
    * @param {String} options.author
    * @param {String} options.content
-   * @param {import("../locales/Locale").default} options.CurrentLocale
    */
   constructor(options) {
-    const { date, title, author, content, CurrentLocale } = options;
+    const { date, title, author, content } = options;
 
     if (!content) {
       ThrowError('E007', 'Article content not specified');
@@ -41,7 +35,6 @@ export default class Article {
     this.#title = title;
     this.#author = author;
     this.#content = content;
-    this.#CurrentLocale = CurrentLocale || null;
   }
 
   /**

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -6,7 +6,6 @@ import FetchAndParseJsonManifest from '../helpers/Manifest/FetchAndParseManifest
 import Constants from '../data/Constants.json';
 import ActiveApiEndpoint from '../data/ActiveApiEndpoint';
 import GetInstalledAddons from '../helpers/AddonInstaller/getInstalledAddons';
-import LocaleContext from '../locales/LocaleContext';
 
 export default function LiveryManager() {
   const [openPage, setOpenPage] = useState('update_feed');

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -9,9 +9,7 @@ import GetInstalledAddons from '../helpers/AddonInstaller/getInstalledAddons';
 import LocaleContext from '../locales/LocaleContext';
 
 export default function LiveryManager() {
-  const CurrentLocale = React.useContext(LocaleContext);
-
-  const [openPage, setOpenPage] = useState('dashboard');
+  const [openPage, setOpenPage] = useState('update_feed');
 
   // Feed state
   const [feed, setFeed] = useState(undefined);
@@ -54,8 +52,6 @@ export default function LiveryManager() {
     setOpenPage(newPage);
   }
 
-  const pg = openPage.toLowerCase();
-
   function UpdateFileList(callback) {
     FetchAndParseJsonManifest(`${ActiveApiEndpoint}/${Constants.api.get.cdnFileListing}`)
       .then(d => {
@@ -73,11 +69,11 @@ export default function LiveryManager() {
     <MainPage
       onTabChange={handlePageChange}
       scrollInnerStyle={
-        openPage.toLowerCase() === 'dashboard'
+        openPage === 'update_feed'
           ? {
               WebkitMaskImage: 'linear-gradient(to bottom, black 90%, transparent 100%)',
             }
-          : openPage.toLowerCase() === 'settings'
+          : openPage === 'settings'
           ? {
               paddingBottom: 100,
               WebkitMaskImage: 'linear-gradient(black calc(90% - 81px), transparent calc(100% - 81px), black calc(100% - 81px), black 100%)',
@@ -85,10 +81,10 @@ export default function LiveryManager() {
           : null
       }
     >
-      <div style={{ display: pg !== CurrentLocale.translate('manager.tabs.tab_labels.update_feed').toLowerCase() && 'none' }}>
+      <div style={{ display: openPage !== 'update_feed' }}>
         <Feed feed={feed} setFeed={setFeed} fullHistory={fullHistory} setFullHistory={setFullHistory} />
       </div>
-      <div style={{ display: pg !== CurrentLocale.translate('manager.tabs.tab_labels.available_liveries').toLowerCase() && 'none' }}>
+      <div style={{ display: openPage !== 'available_liveries' }}>
         <AvailableLiveries
           justRefreshed={justRefreshed}
           setJustRefreshed={setJustRefreshed}
@@ -99,7 +95,7 @@ export default function LiveryManager() {
           setInstalledLiveries={setInstalledLiveries}
         />
       </div>
-      <div style={{ display: pg !== CurrentLocale.translate('manager.tabs.tab_labels.installed_liveries').toLowerCase() && 'none' }}>
+      <div style={{ display: openPage !== 'installed_liveries' }}>
         <InstalledLiveries
           justRefreshed={justRefreshed}
           setJustRefreshed={setJustRefreshed}
@@ -109,7 +105,7 @@ export default function LiveryManager() {
           setInstalledLiveries={setInstalledLiveries}
         />
       </div>
-      <div style={{ display: pg !== CurrentLocale.translate('manager.tabs.tab_labels.settings').toLowerCase() && 'none' }}>
+      <div style={{ display: openPage !== 'settings' }}>
         <Settings />
       </div>
     </MainPage>


### PR DESCRIPTION
**Relates to #183**

## Description

This PR introduces german (de-DE / de) as an additional language. Yay!

In addition, it fixes various i18n-related issues, such as

- locale data other than english not being provided to `dayjs`
- dates not being updated properly after changing language
- tab switching no longer working with new languages / after switching language
- prop types errors in console (pre-existing)

## Checklist

- [X] I have run `yarn format`
- [X] I have run `yarn eslint` and fixed any issues
- [X] This PR does not add any errors to the console
- [ ] I have added this change to the changelog

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos

<details>
<summary>Click to expand</summary>

![livery-manager-de](https://user-images.githubusercontent.com/7271961/100386177-f5756700-3024-11eb-9986-b0658758e62a.gif)

</details>
