### PR TITLE
adds check zip with html content raise error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changed marked with `[DEV]` are invisible to users, and purely for the benefit of developers.
 
+## [0.4.7] - 2022-01-09
+
+### Added
+
+- Fix bug where the downloadprocess halts in process unpacking if the livery is not existing but the process downloads the errorpage as zip file.
+
+### Changed
+
+_None_
+
+### Removed
+
+_None_
+
+### Meta
+
+_None_
+
 ## [0.4.6] - 2021-03-07
 
 ### Added


### PR DESCRIPTION
**Closes #XX**

## Description

At present the download process will halt if the zip file is not found, because a html page is downloaded instead of running into an error, that leads the unzip process to fail.
This change will react on exact that issue.

The new behavior would be:
If the file size of the downloaded zip is below 20kb an error will be thrown, but the process of other working zip files will not be halted.
Additionally the process gets logged and the title of the html page gets tried to be added to the error log.

## Review focus

Try to download e.g.  A320 Neo airfrance-skyteam-fhepi with current version and do the same with the changed version.

## Checklist

- [ x ] I have run `yarn format`
- [ x ] I have run `yarn eslint` and fixed any issues
- [ x ] This PR does not add any errors to the console
- [ x ] I have added this change to the changelog

A build will automatically be run by GitHub actions when any changes are made on this PR. This must complete successfully before merging.

## Screenshots or videos
 
Not needed as there is no visible change

</details>
